### PR TITLE
Do not suppress the python's ImportError exceptions

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -24,12 +24,7 @@ description here (python/__init__.py).
 '''
 from __future__ import unicode_literals
 
-# import swig generated symbols into the correctiq namespace
-try:
-    # this might fail if the module is python-only
-    from .correctiq_swig import *
-except ImportError:
-    pass
+from .correctiq_swig import *
 
 # import any pure python here
 #


### PR DESCRIPTION
Remove the try except block as it contains only a single pass statement
that hides the actual errors when loading the swig files. As this is not
a python only module it's much better to not suppress the errors here.